### PR TITLE
fix: update FiveM API endpoint to frontend.cfx-services.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Available here: [https://igorovh.github.io/fivem-player-list/](https://igorovh.g
 It uses the FiveM endpoint, which is also used in their UI:
 
 ```
-https://servers-frontend.fivem.net/api/servers/single/serverId
+https://frontend.cfx-services.net/api/servers/single/serverId
 ```
 
 # How to get Server ID?

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -1,5 +1,5 @@
 //  endpoints
-export const API_BASE_URL = `https://servers-frontend.fivem.net/api`;
+export const API_BASE_URL = `https://frontend.cfx-services.net/api`;
 export const SERVERS_ICON_URL = 'https://servers-live.fivem.net/servers/icon';
 
 // links templates


### PR DESCRIPTION
Closes #10

The FiveM API has moved to a new domain. The old endpoint `servers-frontend.fivem.net` no longer works, which breaks fetching server & player data.

## Changes
- Updated `API_BASE_URL` in `js/utils/constants.js` to the new domain
- Updated the endpoint reference in the README

**Old:** `https://servers-frontend.fivem.net/api`
**New:** `https://frontend.cfx-services.net/api`

## Testing
Tested against a live server ID (`kqezq7`) → HTTP 200, server info and player list load correctly.